### PR TITLE
Allow to configure VCR reset with no block

### DIFF
--- a/lib/VCR_reset_utils/configuration.rb
+++ b/lib/VCR_reset_utils/configuration.rb
@@ -11,7 +11,7 @@ module VCRResetUtils
     VCR.extend(CassetteCleaner)
 
     self.configuration ||= Configuration.new
-    yield(configuration)
+    yield(configuration) if block_given?
   end
 
   class Configuration


### PR DESCRIPTION
Why?
To allow to configure VCR reset with no block (using default settings)

What?
Allow to configure VCR reset with no block